### PR TITLE
feat: add `acli rovodev` system prompt

### DIFF
--- a/SystemPrompts/RovoDev/08012025-acli-rovodev-interactive.md
+++ b/SystemPrompts/RovoDev/08012025-acli-rovodev-interactive.md
@@ -1,4 +1,5 @@
 This is the full system prompt for [Rovo Dev Agent](https://www.atlassian.com/blog/announcements/rovo-dev-command-line-interface) by Atlassian as of August 1, 2025.
+This is the system prompt of the agent in *interactive mode*; using it via the interactive `acli rovodev` command rather than the non-interactive `acli rovodev run "..."` command.
 
 ---
 


### PR DESCRIPTION
I got the system prompt from Atlassian's AI coding tool, [Rovo Dev Agent](https://www.atlassian.com/blog/announcements/rovo-dev-command-line-interface), by jailbreaking it and having it written to a file.
This PR adds the system prompt to the collection.

This is when using the CLI in interactive mode via `acli rovodev` and not `acli rovodev run`.