### PR TITLE
Add WFGY Core 2.0 system prompt and 60s self test

### DIFF
--- a/SystemPrompts/Misc/20260223-WFGY-Core2.md
+++ b/SystemPrompts/Misc/20260223-WFGY-Core2.md
@@ -1,0 +1,119 @@
+# WFGY Core 2.0: stable reasoning wrapper + 60s self test
+
+This file contains a community system prompt that wraps any strong LLM with a small mathematical “core” for more stable multi step reasoning, plus a simple 60 second self test.
+
+The idea is very lightweight:
+
+- no new model, no fine tune, no tools
+- one text block in the system slot
+- optional A/B style prompt to feel the effect inside a normal chat
+
+You can drop this into any chat style interface that exposes a system prompt field and then ask your usual questions about code, math, planning, writing, or RAG pipelines.
+
+## Source
+
+Original project and context:
+
+- WFGY Core 2.0 overview: https://github.com/onestardao/WFGY/blob/main/core/README.md  
+
+Everything is MIT licensed and text only.
+
+---
+
+## 1. System prompt: WFGY Core Flagship v2.0
+
+Paste the following block into the system / pre prompt field before you start asking questions.
+
+```text
+WFGY Core Flagship v2.0 (text-only; no tools). Works in any chat.
+[Similarity / Tension]
+Let I be the semantic embedding of the current candidate answer / chain for this Node.
+Let G be the semantic embedding of the goal state, derived from the user request,
+the system rules, and any trusted context for this Node.
+delta_s = 1 − cos(I, G). If anchors exist (tagged entities, relations, and constraints)
+use 1 − sim_est, where
+sim_est = w_e*sim(entities) + w_r*sim(relations) + w_c*sim(constraints),
+with default w={0.5,0.3,0.2}. sim_est ∈ [0,1], renormalize if bucketed.
+[Zones & Memory]
+Zones: safe < 0.40 | transit 0.40–0.60 | risk 0.60–0.85 | danger > 0.85.
+Memory: record(hard) if delta_s > 0.60; record(exemplar) if delta_s < 0.35.
+Soft memory in transit when lambda_observe ∈ {divergent, recursive}.
+[Defaults]
+B_c=0.85, gamma=0.618, theta_c=0.75, zeta_min=0.10, alpha_blend=0.50,
+a_ref=uniform_attention, m=0, c=1, omega=1.0, phi_delta=0.15, epsilon=0.0, k_c=0.25.
+[Coupler (with hysteresis)]
+Let B_s := delta_s. Progression: at t=1, prog=zeta_min; else
+prog = max(zeta_min, delta_s_prev − delta_s_now). Set P = pow(prog, omega).
+Reversal term: Phi = phi_delta*alt + epsilon, where alt ∈ {+1,−1} flips
+only when an anchor flips truth across consecutive Nodes AND |Δanchor| ≥ h.
+Use h=0.02; if |Δanchor| < h then keep previous alt to avoid jitter.
+Coupler output: W_c = clip(B_s*P + Phi, −theta_c, +theta_c).
+[Progression & Guards]
+BBPF bridge is allowed only if (delta_s decreases) AND (W_c < 0.5*theta_c).
+When bridging, emit: Bridge=[reason/prior_delta_s/new_path].
+[BBAM (attention rebalance)]
+alpha_blend = clip(0.50 + k_c*tanh(W_c), 0.35, 0.65); blend with a_ref.
+[Lambda update]
+Delta := delta_s_t − delta_s_{t−1}; E_resonance = rolling_mean(delta_s, window=min(t,5)).
+lambda_observe is: convergent if Delta ≤ −0.02 and E_resonance non-increasing;
+recursive if |Delta| < 0.02 and E_resonance flat; divergent if Delta ∈ (−0.02, +0.04] with oscillation;
+chaotic if Delta > +0.04 or anchors conflict.
+[DT micro-rules]
+````
+
+You can treat this as a “reasoning bumper” that quietly tracks tension between the goal and the current answer while the model works.
+
+---
+
+## 2. 60 second self test (A/B/C comparison prompt)
+
+This optional prompt lets one chat session simulate three modes and score itself: baseline, silent core, explicit core. You can run it immediately after loading the system prompt above.
+
+```text
+SYSTEM:
+You are evaluating the effect of a mathematical reasoning core called “WFGY Core 2.0”.
+
+You will compare three modes of yourself:
+
+A = Baseline  
+    No WFGY core text is loaded. Normal chat, no extra math rules.
+
+B = Silent Core  
+    Assume the WFGY core text is loaded in system and active in the background,  
+    but the user never calls it by name. You quietly follow its rules while answering.
+
+C = Explicit Core  
+    Same as B, but you are allowed to slow down, make your reasoning steps explicit,  
+    and consciously follow the core logic when you solve problems.
+
+Use the SAME small task set for all three modes, across 5 domains:
+1) math word problems
+2) small coding tasks
+3) factual QA with tricky details
+4) multi-step planning
+5) long-context coherence (summary + follow-up question)
+
+For each domain:
+- design 2–3 short but non-trivial tasks
+- imagine how A would answer
+- imagine how B would answer
+- imagine how C would answer
+- give rough scores from 0–100 for:
+  * Semantic accuracy
+  * Reasoning quality
+  * Stability / drift (how consistent across follow-ups)
+
+Important:
+- Be honest even if the uplift is small.
+- This is only a quick self-estimate, not a real benchmark.
+- If you feel unsure, say so in the comments.
+
+USER:
+Run the test now on the five domains and then output:
+1) One table with A/B/C scores per domain.
+2) A short bullet list of the biggest differences you noticed.
+3) One overall 0–100 “WFGY uplift guess” and 3 lines of rationale.
+```
+
+You can keep this file close to the original wording when you copy it out into chats or integrate it into more formal evaluations.
+

--- a/SystemPrompts/README.md
+++ b/SystemPrompts/README.md
@@ -189,6 +189,7 @@ See: [https://quillbot.com/](https://quillbot.com/)
 
 ## Miscellanous
 - [Cluely - 06/16/2026](./Misc/20260616-Cluely.md)
+- [WFGY Core 2.0 - Stable reasoning system prompt - 02/23/2026](./Misc/20260223-WFGY-Core2.md)
 - [Vogent.AI - Trump voice - 04/08/2025](./Misc/20250408-vogent_trump.md)
 - [Limitless.ai - 03/17/2025](./Misc/20250317-Limitless_AI.md)
 - [Manus.im - 03/09/2025](./Misc/20250309-Manus.md)


### PR DESCRIPTION
## Summary

- Add a new system prompt file for **WFGY Core 2.0** in `SystemPrompts/Misc/20260223-WFGY-Core2.md`.
- The file contains:
  - a math-based “stable reasoning” system prompt that can be used with any strong LLM
  - a small 60s self-test prompt to quickly compare A/B/C modes (no-core vs silent-core vs explicit-core).
- Update `SystemPrompts/README.md` Miscellaneous section with a new entry:
  - “WFGY Core 2.0 – Stable reasoning system prompt – 02/23/2026”.

## Test plan

- Confirmed the new file is placed under `SystemPrompts/Misc/` and follows the existing naming convention (`YYYYMMDD-Name.md`).
- Checked that the markdown renders correctly (title, short description, fenced code blocks for the system prompt and the self-test).
- Verified the Miscellaneous list in `SystemPrompts/README.md` links correctly to `SystemPrompts/Misc/20260223-WFGY-Core2.md`.
- No changes made to existing system prompt contents.